### PR TITLE
[sonar] Remove dependency on :downloadNode

### DIFF
--- a/sonar/src/gradle/README.md
+++ b/sonar/src/gradle/README.md
@@ -87,3 +87,6 @@ sonarqube {
     }
 }
 ```  
+
+### Analyzing CSS / JS
+If you include some CSS / JS files in the 'sonar.source', make sure to have a valid NodeJS executable in PATH o provide the path manually via `-Dsonar.nodejs.executable=...` on command line o in your `gradle*.properties`.

--- a/sonar/src/gradle/gradle.properties
+++ b/sonar/src/gradle/gradle.properties
@@ -42,6 +42,9 @@
     # If you want 'src' directories of themes to be analyzed for NPM themes, use 'src'
     # as the value.
     #
+    # Note: You will also need to provide '-Dsonar.nodejs.executable=...' pointing
+    # to a NodeJS executable (e.g. '/usr/bin/node') to  be used for analysis.
+    #
     # Can be customized per-project.
     #liferay.sonar.theme.npm.sources.dirs=
 

--- a/sonar/src/gradle/sonar.gradle
+++ b/sonar/src/gradle/sonar.gradle
@@ -84,13 +84,6 @@ generatedJavaFilesExcluded= ${generatedJavaFilesExcluded} | themeNpmSourcesDirs=
             properties['sonar.sources'] = properties['sonar.sources'] ?: []
             properties['sonar.tests'] = properties['sonar.tests'] ?: []
             properties['sonar.exclusions'] = properties['sonar.exclusions'] ?: []
-
-            // For CSS / JS analysis
-            if (!System.getProperty('sonar.nodejs.executable')) {
-                // Note: the default will not work on Windows, but Sonar should typically only be invoked via Jenkins (linux node)
-                // TODO find the default path from some workspace task
-                properties['sonar.nodejs.executable'] = rootProject.file('build/node/bin/node')
-            }
         }
     }
 
@@ -201,9 +194,6 @@ def sonarqubePropsCheck = tasks.create('sonarqubePropsCheck') {
 }
 
 tasks.findByPath(':sonarqube').configure {
-    // For CSS / JS analysis
-    dependsOn ':downloadNode'
-
     // Run all the checks first
     dependsOn sonarqubePropsCheck
 }


### PR DESCRIPTION
- might not always be added
- up to the called to supply the 'sonar.nodejs.executable' if CSS / JS analysis is desired