### PR TITLE
GSOP-497 Use scope to name our custom NPM modules

### DIFF
--- a/gpr/src/gradleTest/gpr-publishing-local/themes/jarvis-theme/package.json
+++ b/gpr/src/gradleTest/gpr-publishing-local/themes/jarvis-theme/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "jarvis-theme",
+	"name": "@lfr-solution-desk/jarvis-theme",
 	"version": "1.0.0",
 	"main": "package.json",
 	"keywords": [

--- a/sonar/src/gradleTest/sonar-push/themes/jarvis-theme/package.json
+++ b/sonar/src/gradleTest/sonar-push/themes/jarvis-theme/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "jarvis-theme",
+	"name": "@lfr-solution-desk/jarvis-theme",
 	"version": "1.0.0",
 	"main": "package.json",
 	"keywords": [


### PR DESCRIPTION
Only used in tests, but still fixing just in case.